### PR TITLE
Quizard API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,98 @@
+# API Docs – Quiz App
+
+## 1. Overview
+
+Environments
+
+- Local dev server [http://localhost:3001](http://localhost:3001)
+
+## 2. Authentication
+
+A middleware is sketched out with a hardcoded user ID in this demo. Incoming requests to all routes in this API are decorated with the user ID.
+
+## 3. Endpoints Reference
+
+### 3.1 Quizzes
+
+#### `GET /quizzes`
+
+##### Response
+
+```json
+{ "items": [{ "id": "1", "title": "Skeletal Basics" }] }
+```
+
+#### `GET /quizzes/{quizId}`
+
+##### Query params
+
+- quizId: quiz ID.
+
+##### Response
+
+```json
+{
+  "id": "1",
+  "title": "Skeletal Basics",
+  "created_at": "2025-08-22T15:00:00Z"
+}
+```
+
+#### `GET /quizzes/{quizId}/questions`
+
+##### Query params
+
+- quizId: ID of the quiz the questions belong to.
+
+##### Response
+
+```json
+[
+  {
+    "id": "1",
+    "quiz_id": "Skeletal Basics",
+    "question_content": "Which bone is the longest in the human body?",
+    "choices": "Femur;;Tibia;;Humerus;;Fibula",
+    "created_at": "2025-08-22T15:00:00Z"
+  }
+]
+```
+
+## 5. Schemas
+
+Quiz
+
+```json
+{
+  "id": "string",
+  "title": "Skeletal Systems Basics",
+  "created_at": "2025-08-22T15:10:00Z"
+}
+```
+
+Question
+
+```json
+{
+  "id": "string",
+  "quiz_id": "string",
+  "question_content": "What is the common name for the clavicle?",
+  "choices": "Collarbone;;Wishbone;;Shoulderblade;;Neckbone",
+  "created_at": "2025-08-22T15:10:00Z"
+}
+```
+
+Error
+
+```json
+{ "error": { "code": "string", "message": "string", "details": {} } }
+```
+
+## 6. Error Catalog
+
+Not implemented yet, but these are possible errors for invalid answer selection payload
+
+- 400 invalid_payload
+- 401 unauthorized
+- 404 not_found
+- 409 conflict_out_of_order or conflict_duplicate_submit

--- a/backend/model.ts
+++ b/backend/model.ts
@@ -1,0 +1,19 @@
+export interface Quiz {
+	id: number;
+	title: string;
+	created_at: Date;
+}
+
+export interface Question {
+	id: number;
+	quiz_id: number;
+	question_content: string;
+	choices: string;
+	created_at: Date;
+}
+
+export interface User {
+	id: number;
+	name: string;
+	email: string;
+}

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,5 +1,8 @@
 import cors from "@fastify/cors";
-import fastify, { type RouteGenericInterface } from "fastify";
+import fastify, {
+	type FastifyPluginCallback,
+	type RouteGenericInterface,
+} from "fastify";
 import { db } from "./db-client";
 import type { Question, Quiz, User } from "./model";
 
@@ -15,9 +18,23 @@ interface QuizzesRouteGeneric extends RouteGenericInterface {
 	};
 }
 
+const authMiddleware: FastifyPluginCallback = (fastify, _opts, done) => {
+	fastify.decorateRequest("user", null);
+
+	fastify.addHook("preHandler", (req, _reply, done) => {
+		// stub: Get user here
+
+		req.user = { id: "1" };
+		done();
+	});
+
+	done();
+};
+
 const server = fastify();
 
 server.register(cors, {});
+server.register(authMiddleware);
 
 const PORT = +(process.env.BACKEND_SERVER_PORT ?? 3001);
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -31,6 +31,15 @@ server.get("/users", (_request, reply) => {
 	reply.send({ data });
 });
 
+/** GET /me fetches the session user's details (hardcoded in demo)  */
+server.get("/me", (request, reply) => {
+	const data = db.prepare<{ id: string }, User[]>(
+		"SELECT * FROM users WHERE id = :id",
+	);
+
+	reply.send({ data: data.get({ id: request.user?.id ?? "1" }) });
+});
+
 /** GET /quizzes fetches all quizzes */
 server.get("/quizzes", (_request, reply) => {
 	const data = db.prepare<[], Quiz[]>("SELECT * FROM quizzes").all();


### PR DESCRIPTION
## Context

This PR adds `/me` endpoint, an auth middleware, and the model of resource schema. 

## Changes

- New endpoint `GET /me` to fetch a user's (future) quiz performance history
- Auth middleware that can decorate requests with the session user's information (hardcoded user for now)
- Models that define resources `Quiz, Questions, User`


## TODO

At a later time, tests should be added. More detailed logging should be added as well.