### PR TITLE
Add `attempts` feature to API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -197,3 +197,25 @@ Not implemented yet, but these are possible errors for invalid answer selection 
 - 401 unauthorized
 - 404 not_found
 - 409 conflict_out_of_order or conflict_duplicate_submit
+
+ <!--
+- Should store attempt information, like time taken, how many times paused, final score
+- Ideally collect data from the quiz attempts to build a growth plan for student
+- Behavior analysis per question–collect time taken per question? see if AI can see a pattern
+ -->
+
+# Trade offs
+
+- _Updating answer choices on every question advance._ The choices are important data to save because they directly influence the final score. The final score is a part of licensure or employment success so should be treated with high fidelity and security.
+
+# Possible optimizations
+
+- _Question answer key table._ Answer keys could have been stored by a hashed column on the quiz_questions table. But an entirely separate table is better for least privilege and allows audit. endpoints that fetch quizzes never touch this table. Cons is that you have to do an extra join when grading, introduces more code lift and latency, and possible schema drift. I optimized for preventing leaks.
+- A middleware for `attempt.user_id` ownership check.
+
+# Notes about what I did
+
+- I did not implement a dedicated `GET /quizzes/{id}` endpoint, since `GET /quizzes` returns all the necessary data to display a detail page for each quiz.
+- Technically you could grade both MCQ and FT (free text) questions with LLM, but would incur increased infrastructural cost.
+- In production, I would not use autoincrementing integer as the primary key of a sensitive table like answer_keys.
+- `quiz` should have a `version` column and `attempt` should have a corresponding `quiz_version` so outdated attempts should be invalidated.

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,11 +8,24 @@ Environments
 
 ## 2. Authentication
 
-A middleware is sketched out with a hardcoded user ID in this demo. Incoming requests to all routes in this API are decorated with the user ID.
+A middleware is sketched out with a hardcoded user ID in this demo. Incoming requests to all routes in this API are decorated with the user ID. This was meaningful because the Resume feature involves attempts which are user-scoped.
 
-## 3. Endpoints Reference
+## 3. Resource Model
 
-### 3.1 Quizzes
+Entities
+
+- `Quiz`: id title version questions[]
+- `Attempt`: id quizId userId current score finished updatedAt version
+
+Invariants
+
+- An attempt belongs to one user and one quiz.
+- A user may only have one unfinished attempt per quiz.
+- Finished attempts are immutable (not implemented yet)
+
+## 4. Endpoints Reference
+
+### 4.1 Quizzes
 
 #### `GET /quizzes`
 
@@ -58,6 +71,90 @@ A middleware is sketched out with a hardcoded user ID in this demo. Incoming req
 ]
 ```
 
+### 4.2 Attempts
+
+#### `POST /quizzes/{quizId}/attempts`
+
+Ensure or create active attempt for quiz with the provided ID.
+
+##### Query Params
+
+- quizId: quiz ID.
+
+##### Response
+
+Returns the created attempt object.
+
+```json
+{
+  "id": "0",
+  "quizId": "1",
+  "score": 0,
+  "finished": 0,
+  "updatedAt": "2025-08-22T15:00:00Z"
+}
+```
+
+#### `GET /quizzes/{quizId}/attempts/active`
+
+##### Query Params
+
+- quizId: quiz ID.
+
+##### Response
+
+Returns an unfinished attempt for given quiz, if any.
+
+```json
+{
+  "id": "0",
+  "quizId": "1",
+  "score": 1,
+  "finished": 0,
+  "updatedAt": "2025-08-22T15:05:00Z"
+}
+```
+
+#### `GET /attempts/{attemptId}`
+
+##### Query Params
+
+- attemptId: ID of a specific attempt.
+
+##### Response
+
+Gets a specific attempt with the given ID.
+
+```json
+{
+  "id": "0",
+  "quizId": "1",
+  "score": 1,
+  "finished": 0,
+  "updatedAt": "2025-08-22T15:05:00Z"
+}
+```
+
+#### `POST /attempts/{attemptId}/finish`
+
+##### Query Params
+
+- attemptId: ID of the attempt to complete.
+
+##### Response
+
+Updates the specified attempt to mark a completed quiz attempt. This means the attempt is graded and should have a score.
+
+```json
+{
+  "id": "0",
+  "quizId": "1",
+  "score": 4,
+  "finished": 1,
+  "updatedAt": "2025-08-22T15:10:00Z"
+}
+```
+
 ## 5. Schemas
 
 Quiz
@@ -65,20 +162,24 @@ Quiz
 ```json
 {
   "id": "string",
-  "title": "Skeletal Systems Basics",
-  "created_at": "2025-08-22T15:10:00Z"
+  "title": "string",
+  "version": 0,
+  "questions": [{ "id": "string", "prompt": "string", "choices": ["string"] }]
 }
 ```
 
-Question
+Attempt
 
 ```json
 {
   "id": "string",
-  "quiz_id": "string",
-  "question_content": "What is the common name for the clavicle?",
-  "choices": "Collarbone;;Wishbone;;Shoulderblade;;Neckbone",
-  "created_at": "2025-08-22T15:10:00Z"
+  "quizId": "string",
+  "userId": "string",
+  "current": 0,
+  "score": 0,
+  "finished": false,
+  "version": 0,
+  "updatedAt": "ISO-8601"
 }
 ```
 
@@ -90,7 +191,7 @@ Error
 
 ## 6. Error Catalog
 
-Not implemented yet, but these are possible errors for invalid answer selection payload
+Not implemented yet, but these are possible errors for invalid answer selection payload, mismatching userId on an attempt, etc.
 
 - 400 invalid_payload
 - 401 unauthorized

--- a/backend/README.md
+++ b/backend/README.md
@@ -87,11 +87,14 @@ Returns the created attempt object.
 
 ```json
 {
-  "id": "0",
-  "quizId": "1",
-  "score": 0,
-  "finished": 0,
-  "updatedAt": "2025-08-22T15:00:00Z"
+  "id": "1",
+  "quiz_id": "1",
+  "user_id": "1",
+  "answer_selections": "",
+  "is_finished": 0,
+  "time_elapsed": 0,
+  "score": null,
+  "updated_at": "2025-08-22T15:10:00Z"
 }
 ```
 
@@ -107,11 +110,14 @@ Returns an unfinished attempt for given quiz, if any.
 
 ```json
 {
-  "id": "0",
-  "quizId": "1",
-  "score": 1,
-  "finished": 0,
-  "updatedAt": "2025-08-22T15:05:00Z"
+  "id": "1",
+  "quiz_id": "1",
+  "user_id": "1",
+  "answer_selections": "{\"1\": \"Tibia\", \"3\": \"Example answer here\"}",
+  "is_finished": 0,
+  "time_elapsed": 0,
+  "score": null,
+  "updated_at": "2025-08-22T15:10:00Z"
 }
 ```
 
@@ -127,11 +133,37 @@ Gets a specific attempt with the given ID.
 
 ```json
 {
-  "id": "0",
-  "quizId": "1",
-  "score": 1,
-  "finished": 0,
-  "updatedAt": "2025-08-22T15:05:00Z"
+  "id": "1",
+  "quiz_id": "1",
+  "user_id": "1",
+  "answer_selections": "",
+  "is_finished": 0,
+  "time_elapsed": 0,
+  "score": null,
+  "updated_at": "2025-08-22T15:10:00Z"
+}
+```
+
+#### `POST /attempts/{attemptId}/answer`
+
+##### Query Params
+
+- attemptId: ID of the attempt to update.
+
+##### Response
+
+Updates the specified attempt field `answer_selections` with a JSON blob. The JSON blob is a key-value pair of question ID and the answer choice/text selected by the student.
+
+```json
+{
+  "id": "1",
+  "quiz_id": "1",
+  "user_id": "1",
+  "answer_selections": "{\"1\": \"Tibia\", \"2\": \"Tibia\", \"3\": \"Example answer here\"}",
+  "is_finished": 0,
+  "time_elapsed": 0,
+  "score": null,
+  "updated_at": "2025-08-22T15:10:00Z"
 }
 ```
 
@@ -147,11 +179,14 @@ Updates the specified attempt to mark a completed quiz attempt. This means the a
 
 ```json
 {
-  "id": "0",
-  "quizId": "1",
+  "id": "1",
+  "quiz_id": "1",
+  "user_id": "1",
+  "answer_selections": "{\"1\": \"Tibia\", \"2\": \"Tibia\", \"3\": \"Example answer here\"}",
+  "is_finished": 1,
+  "time_elapsed": 2495,
   "score": 4,
-  "finished": 1,
-  "updatedAt": "2025-08-22T15:10:00Z"
+  "updated_at": "2025-08-22T15:10:00Z"
 }
 ```
 
@@ -173,13 +208,12 @@ Attempt
 ```json
 {
   "id": "string",
-  "quizId": "string",
-  "userId": "string",
-  "current": 0,
+  "quiz_id": "string",
+  "user_id": "string",
+  "answer_selections": "string",
   "score": 0,
-  "finished": false,
-  "version": 0,
-  "updatedAt": "ISO-8601"
+  "is_finished": false,
+  "updated_at": "ISO-8601"
 }
 ```
 

--- a/backend/model.ts
+++ b/backend/model.ts
@@ -1,3 +1,15 @@
+export interface Attempt {
+	id: number;
+	user_id: number;
+	quiz_id: number;
+	is_finished: boolean;
+	answer_selections: string | undefined;
+	time_elapsed: number | undefined;
+	score: number | undefined;
+	created_at: Date;
+	updated_at: Date;
+}
+
 export interface Quiz {
 	id: number;
 	title: string;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -133,6 +133,31 @@ server.post<QuizzesRouteGeneric>("/quizzes/:id/attempts", (request, reply) => {
 	reply.send({ data: newAttempt.get({ id: String(insert.lastInsertRowid) }) });
 });
 
+/** GET /attempts fetches all attempts belonging to a user across all quizzes */
+server.get("/attempts", (request, reply) => {
+	const userId = String(request.user?.id ?? 1);
+	const data = db.prepare<{ userId: string }, Attempt[]>(`
+			SELECT ${ATTEMPTS_BASE_QUERY}
+			FROM ${ATTEMPTS_TABLE_NAME}
+			WHERE user_id = :userId
+		`);
+
+	reply.send({ data: data.all({ userId }) });
+});
+
+/** GET /attempts/{id} fetches a user-scoped quiz attempt by ID */
+server.get<AttemptsRouteGeneric>("/attempts/:id", (request, reply) => {
+	const userId = String(request.user?.id ?? 1);
+	const data = db.prepare<{ id: string; userId: string }, Attempt>(`
+			SELECT ${ATTEMPTS_BASE_QUERY}
+			FROM ${ATTEMPTS_TABLE_NAME}
+			WHERE id = :id
+			AND user_id = :userId
+		`);
+
+	reply.send({ data: data.get({ id: request.params.id, userId }) });
+});
+
 /**
  * Run server
  */

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -4,7 +4,7 @@ import fastify, {
 	type RouteGenericInterface,
 } from "fastify";
 import { db } from "./db-client";
-import type { Question, Quiz, User } from "./model";
+import type { Attempt, Question, Quiz, User } from "./model";
 
 declare module "fastify" {
 	interface FastifyRequest {
@@ -13,6 +13,12 @@ declare module "fastify" {
 }
 
 interface QuizzesRouteGeneric extends RouteGenericInterface {
+	Params: {
+		id: string;
+	};
+}
+
+interface AttemptsRouteGeneric extends RouteGenericInterface {
 	Params: {
 		id: string;
 	};
@@ -45,7 +51,7 @@ server.get("/", async (_request, _reply) => {
 server.get("/users", (_request, reply) => {
 	const data = db.prepare<[], User[]>("SELECT * FROM users").all();
 
-	reply.send({ data });
+	return { data };
 });
 
 /** GET /me fetches the session user's details (hardcoded in demo)  */
@@ -82,6 +88,49 @@ server.get<QuizzesRouteGeneric>("/quizzes/:id/questions", (request, reply) => {
 	`);
 
 	reply.send({ data: data.all({ id: request.params.id }) });
+});
+
+const ATTEMPTS_BASE_QUERY =
+	"id, quiz_id, answer_selections, is_finished, created_at, updated_at";
+const ATTEMPTS_TABLE_NAME = "attempts";
+
+/** POST /quizzes/:id/attempts reads or creates an attempt for a quiz */
+server.post<QuizzesRouteGeneric>("/quizzes/:id/attempts", (request, reply) => {
+	const userId = String(request.user?.id ?? 1);
+	const quizId = String(request.params.id);
+
+	// Do they already have an active attempt for this quiz?
+	const data = db.prepare<{ userId: string; quizId: string }, Attempt>(`
+			SELECT ${ATTEMPTS_BASE_QUERY}
+			FROM ${ATTEMPTS_TABLE_NAME}
+			WHERE user_id = :userId
+			AND quiz_id = :quizId
+			AND is_finished = 0
+		`);
+
+	const attempt = data.get({ userId, quizId });
+
+	if (attempt) {
+		reply.send({ data: attempt });
+	}
+
+	// Otherwise, make a new attempt
+	const insertStmt = db.prepare<{ userId: string; quizId: string }, Attempt>(`
+		INSERT INTO attempts
+			(user_id, quiz_id)
+		VALUES
+			(:userId, :quizId)
+	`);
+	const insert = insertStmt.run({ userId, quizId });
+
+	const newAttempt = db.prepare<{ id: string }, Attempt>(`
+			SELECT
+				${ATTEMPTS_BASE_QUERY}
+			FROM ${ATTEMPTS_TABLE_NAME}
+			WHERE id = :id
+		`);
+
+	reply.send({ data: newAttempt.get({ id: String(insert.lastInsertRowid) }) });
 });
 
 /**


### PR DESCRIPTION
## Context

The attempts feature enables quiz progress to be saved so that the student can resume a quiz when they navigate away. This PR adds the necessary resource schema and endpoints and handlers to enable this feature.

## Changes

- `POST /quizzes/{quizId}/attempts`
- `GET /quizzes/{quizId}/attempts/active`
- `GET /attempts/{attemptId}`
- `POST /attempts/{attemptId}/answer`
- `POST /attempts/{attemptId}/finish`
